### PR TITLE
chore: point clients at the `encrypted-tx-inputs` branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ bin/faucet/frontend/bundle.js
 
 # Ignore mdbook build files
 book/
+*.sqlite3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4531,7 +4531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4590,7 +4590,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4971,7 +4971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5138,7 +5138,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5157,7 +5157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6159,7 +6159,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.16.0-alpha.1"
-source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=next#cf510e39fafa647aea8fb863ba779e92a8f7d9c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "miden-client-cli"
 version = "0.16.0-alpha.1"
-source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=next#cf510e39fafa647aea8fb863ba779e92a8f7d9c2"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "miden-client-sqlite-store"
 version = "0.16.0-alpha.1"
-source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=next#cf510e39fafa647aea8fb863ba779e92a8f7d9c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2706,7 +2706,6 @@ dependencies = [
  "miden-faucet-lib",
  "miden-node-proto-build",
  "miden-pow-rate-limiter",
- "miden-protocol",
  "miden-testing",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2889,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.16.0-alpha.2"
-source = "git+https://github.com/0xMiden/node.git?rev=74e4f327b8f654d95afefaea0e9f74a7a4571cd9#74e4f327b8f654d95afefaea0e9f74a7a4571cd9"
+source = "git+https://github.com/0xMiden/node.git?rev=b4ece8c9036745840e1cdd904a10b573283c37e2#b4ece8c9036745840e1cdd904a10b573283c37e2"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3291,7 +3290,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4532,7 +4531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4591,7 +4590,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4972,7 +4971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5139,7 +5138,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5158,7 +5157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6160,7 +6159,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2505,8 +2505,7 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.16.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd62f7d71b6cdda10ac53030c5f47ee50beecfa04ab6b855bbf495413446b"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2544,8 +2543,7 @@ dependencies = [
 [[package]]
 name = "miden-client-cli"
 version = "0.16.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f0e9b22a1ca9542c88de8adf3f996dec87ef475911f797086915982737bfba"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2566,8 +2564,7 @@ dependencies = [
 [[package]]
 name = "miden-client-sqlite-store"
 version = "0.16.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6edb298af467ce3b6c7628fab94ee3d998b86dad6b1efb525d55aedfa3951e9"
+source = "git+https://github.com/0xMiden/rust-sdk?branch=encrypted-tx-inputs#32dfba8df1eb5910a189b023365aa644f8efbdcb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,6 +2706,7 @@ dependencies = [
  "miden-faucet-lib",
  "miden-node-proto-build",
  "miden-pow-rate-limiter",
+ "miden-protocol",
  "miden-testing",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2891,8 +2889,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.16.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1027cbad81e3f7a59b50be02cd27c22766573388fce96a807615f2bec0d5fc"
+source = "git+https://github.com/0xMiden/node.git?rev=74e4f327b8f654d95afefaea0e9f74a7a4571cd9#74e4f327b8f654d95afefaea0e9f74a7a4571cd9"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3294,7 +3291,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4535,7 +4532,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4594,7 +4591,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4975,7 +4972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5142,7 +5139,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5161,7 +5158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6163,7 +6160,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ miden-faucet-lib       = { path = "crates/faucet", version = "0.16.0-alpha.1" }
 miden-pow-rate-limiter = { path = "crates/pow", version = "0.16.0-alpha.1" }
 
 # Miden dependencies.
-miden-client              = { version = "0.16.0-alpha.1" }
-miden-client-cli          = { version = "0.16.0-alpha.1" }
-miden-client-sqlite-store = { version = "0.16.0-alpha.1" }
+miden-client              = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-cli          = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-sqlite-store = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
 
 # External dependencies
 anyhow                = { version = "1.0" }
@@ -65,13 +65,3 @@ module_name_repetitions     = "allow" # Many triggers, and is a stylistic choice
 must_use_candidate          = "allow" # This marks many fn's which isn't helpful.
 should_panic_without_expect = "allow" # We don't care about the specific panic message.
 # End of pedantic lints.
-
-# TEMPORARY: points the client crates at the rust-sdk next branch, which carries the
-# encrypted-transaction-inputs work (0xMiden/rust-sdk#2341), pending the next alpha release.
-[patch.crates-io]
-miden-client              = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
-miden-client-cli          = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
-miden-client-sqlite-store = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
-# The stub node's protos must match the node line the patched client speaks, which includes
-# the transaction encryption key endpoint.
-miden-node-proto-build = { git = "https://github.com/0xMiden/node.git", rev = "b4ece8c9036745840e1cdd904a10b573283c37e2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,12 @@ must_use_candidate          = "allow" # This marks many fn's which isn't helpful
 should_panic_without_expect = "allow" # We don't care about the specific panic message.
 # End of pedantic lints.
 
-# TEMPORARY: points the client crates at the encrypted-transaction-inputs branch
-# (0xMiden/rust-sdk#2341), pending the next alpha release.
+# TEMPORARY: points the client crates at the rust-sdk next branch, which carries the
+# encrypted-transaction-inputs work (0xMiden/rust-sdk#2341), pending the next alpha release.
 [patch.crates-io]
-miden-client              = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
-miden-client-cli          = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
-miden-client-sqlite-store = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client              = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-cli          = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-sqlite-store = { branch = "next", git = "https://github.com/0xMiden/rust-sdk" }
 # The stub node's protos must match the node line the patched client speaks, which includes
 # the transaction encryption key endpoint.
-miden-node-proto-build = { git = "https://github.com/0xMiden/node.git", rev = "74e4f327b8f654d95afefaea0e9f74a7a4571cd9" }
+miden-node-proto-build = { git = "https://github.com/0xMiden/node.git", rev = "b4ece8c9036745840e1cdd904a10b573283c37e2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,13 @@ module_name_repetitions     = "allow" # Many triggers, and is a stylistic choice
 must_use_candidate          = "allow" # This marks many fn's which isn't helpful.
 should_panic_without_expect = "allow" # We don't care about the specific panic message.
 # End of pedantic lints.
+
+# TEMPORARY: points the client crates at the encrypted-transaction-inputs branch
+# (0xMiden/rust-sdk#2341), pending the next alpha release.
+[patch.crates-io]
+miden-client              = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-cli          = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
+miden-client-sqlite-store = { branch = "encrypted-tx-inputs", git = "https://github.com/0xMiden/rust-sdk" }
+# The stub node's protos must match the node line the patched client speaks, which includes
+# the transaction encryption key endpoint.
+miden-node-proto-build = { git = "https://github.com/0xMiden/node.git", rev = "74e4f327b8f654d95afefaea0e9f74a7a4571cd9" }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -65,7 +65,7 @@ uuid          = { workspace = true }
 # Used to generate the node RPC types for the stub node used in tests 
 # (so the dependency only lies in the protobuf interface).
 [build-dependencies]
-miden-node-proto-build = { version = "0.16.0-alpha.2" }
+miden-node-proto-build = { git = "https://github.com/0xMiden/node.git", rev = "b4ece8c9036745840e1cdd904a10b573283c37e2" }
 tonic-prost-build      = { version = "0.14" }
 
 # Required to avoid false positives in cargo-machete

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -51,16 +51,17 @@ tracing-subscriber    = { workspace = true }
 url                   = { workspace = true }
 
 [dev-dependencies]
-fantoccini    = { version = "0.22" }
-miden-client  = { features = ["testing"], workspace = true }
-miden-testing = { default-features = false, version = "0.16.0-alpha.2" }
-prost         = { version = "0.14" }
-reqwest       = { features = ["json"], workspace = true }
-serde_json    = { workspace = true }
-tokio         = { features = ["macros", "process"], workspace = true }
-tonic-prost   = { version = "0.14" }
-tonic-web     = { version = "0.14" }
-uuid          = { workspace = true }
+fantoccini     = { version = "0.22" }
+miden-client   = { features = ["testing"], workspace = true }
+miden-protocol = { version = "0.16.0-alpha.4" }
+miden-testing  = { default-features = false, version = "0.16.0-alpha.2" }
+prost          = { version = "0.14" }
+reqwest        = { features = ["json"], workspace = true }
+serde_json     = { workspace = true }
+tokio          = { features = ["macros", "process"], workspace = true }
+tonic-prost    = { version = "0.14" }
+tonic-web      = { version = "0.14" }
+uuid           = { workspace = true }
 
 # Used to generate the node RPC types for the stub node used in tests 
 # (so the dependency only lies in the protobuf interface).

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -51,17 +51,16 @@ tracing-subscriber    = { workspace = true }
 url                   = { workspace = true }
 
 [dev-dependencies]
-fantoccini     = { version = "0.22" }
-miden-client   = { features = ["testing"], workspace = true }
-miden-protocol = { version = "0.16.0-alpha.4" }
-miden-testing  = { default-features = false, version = "0.16.0-alpha.2" }
-prost          = { version = "0.14" }
-reqwest        = { features = ["json"], workspace = true }
-serde_json     = { workspace = true }
-tokio          = { features = ["macros", "process"], workspace = true }
-tonic-prost    = { version = "0.14" }
-tonic-web      = { version = "0.14" }
-uuid           = { workspace = true }
+fantoccini    = { version = "0.22" }
+miden-client  = { features = ["testing"], workspace = true }
+miden-testing = { default-features = false, version = "0.16.0-alpha.2" }
+prost         = { version = "0.14" }
+reqwest       = { features = ["json"], workspace = true }
+serde_json    = { workspace = true }
+tokio         = { features = ["macros", "process"], workspace = true }
+tonic-prost   = { version = "0.14" }
+tonic-web     = { version = "0.14" }
+uuid          = { workspace = true }
 
 # Used to generate the node RPC types for the stub node used in tests 
 # (so the dependency only lies in the protobuf interface).

--- a/bin/faucet/frontend/package.json
+++ b/bin/faucet/frontend/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@demox-labs/miden-wallet-adapter-base": "^0.10.0",
     "@demox-labs/miden-wallet-adapter-miden": "^0.10.0",
-    "@miden-sdk/miden-sdk": "^0.16.0-alpha.1"
+    "@miden-sdk/miden-sdk": "file:./miden-sdk-miden-sdk-0.16.0-alpha.1.tgz"
   },
   "devDependencies": {
     "esbuild": "^0.27.0"

--- a/bin/faucet/src/testing/stub_rpc_api.rs
+++ b/bin/faucet/src/testing/stub_rpc_api.rs
@@ -2,10 +2,10 @@ use std::sync::OnceLock;
 
 use anyhow::Context;
 use miden_client::block::{BlockHeader, ValidatorKeys};
+use miden_client::crypto::ecdsa_k256_keccak::SigningKey;
 use miden_client::crypto::eddsa_25519_sha512::KeyExchangeKey;
 use miden_client::rpc::encryption::attestation_commitment;
 use miden_client::utils::Serializable;
-use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
 use miden_testing::MockChain;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -258,7 +258,7 @@ impl api_server::Api for StubRpcApi {
             block_range: Some(proto::rpc::BlockRange { block_from: 0, block_to: 0 }),
             mmr_delta: Some(proto::primitives::MmrDelta { forest: 0, data: vec![] }),
             block_header: Some(to_proto_block_header(&stub_chain().genesis)),
-            block_signature: None,
+            block_signatures: vec![],
         }))
     }
 

--- a/bin/faucet/src/testing/stub_rpc_api.rs
+++ b/bin/faucet/src/testing/stub_rpc_api.rs
@@ -1,4 +1,11 @@
+use std::sync::OnceLock;
+
 use anyhow::Context;
+use miden_client::block::{BlockHeader, ValidatorKeys};
+use miden_client::crypto::eddsa_25519_sha512::KeyExchangeKey;
+use miden_client::rpc::encryption::attestation_commitment;
+use miden_client::utils::Serializable;
+use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
 use miden_testing::MockChain;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -10,6 +17,54 @@ use super::proto;
 use super::proto::rpc::api_server;
 use super::proto::to_proto_block_header;
 
+/// Wire identifier of `IES_SCHEME_X25519_XCHACHA20_POLY1305`, the scheme the client seals for.
+const IES_SCHEME_X25519_XCHACHA20_POLY1305: i32 = 1;
+
+/// Chain state served by the stub.
+///
+/// The header is stable across requests and commits to a validator signing key the stub holds,
+/// so the transaction encryption key it serves carries an attestation the client can verify
+/// against the header it previously stored.
+struct StubChain {
+    genesis: BlockHeader,
+    validator_signer: SigningKey,
+    encryption_key: KeyExchangeKey,
+}
+
+fn stub_chain() -> &'static StubChain {
+    static STATE: OnceLock<StubChain> = OnceLock::new();
+    STATE.get_or_init(|| {
+        let validator_signer = SigningKey::new();
+        let encryption_key = KeyExchangeKey::new();
+        let validator_keys = ValidatorKeys::new(vec![validator_signer.public_key()])
+            .expect("a single-key validator set is valid");
+
+        // Only the validator set matters to the stub's consumers; every other field is taken
+        // from a mock header so the roots stay well-formed.
+        let template = MockChain::new().latest_block_header();
+        let genesis = BlockHeader::new(
+            template.version(),
+            template.prev_block_commitment(),
+            template.block_num(),
+            template.chain_commitment(),
+            template.account_root(),
+            template.nullifier_root(),
+            template.note_root(),
+            template.tx_commitment(),
+            template.tx_kernel_commitment(),
+            validator_keys,
+            template.fee_parameters().clone(),
+            template.timestamp(),
+        );
+
+        StubChain {
+            genesis,
+            validator_signer,
+            encryption_key,
+        }
+    })
+}
+
 pub struct StubRpcApi;
 
 #[tonic::async_trait]
@@ -18,12 +73,41 @@ impl api_server::Api for StubRpcApi {
         &self,
         _request: Request<proto::rpc::BlockHeaderByNumberRequest>,
     ) -> Result<Response<proto::rpc::BlockHeaderByNumberResponse>, Status> {
-        let mock_chain = MockChain::new();
-
         Ok(Response::new(proto::rpc::BlockHeaderByNumberResponse {
-            block_header: Some(to_proto_block_header(&mock_chain.latest_block_header())),
+            block_header: Some(to_proto_block_header(&stub_chain().genesis)),
             mmr_path: None,
             chain_length: None,
+        }))
+    }
+
+    async fn get_transaction_encryption_key(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<proto::transaction::TransactionEncryptionKey>, Status> {
+        let chain = stub_chain();
+        let key_id = b"stub-key-id".to_vec();
+        let public_key = chain.encryption_key.public_key().to_bytes();
+
+        // The commitment layout is mirrored from the validator; signing it with the key
+        // committed in the stub's header makes the attestation verify on the client.
+        let commitment = attestation_commitment(
+            IES_SCHEME_X25519_XCHACHA20_POLY1305 as u32,
+            &key_id,
+            chain.genesis.commitment(),
+            &public_key,
+            None,
+        );
+        let signature = chain.validator_signer.sign(commitment);
+
+        Ok(Response::new(proto::transaction::TransactionEncryptionKey {
+            scheme: IES_SCHEME_X25519_XCHACHA20_POLY1305,
+            key_id,
+            public_key,
+            attestations: vec![proto::transaction::ValidatorKeyAttestation {
+                validator_public_key: chain.validator_signer.public_key().to_bytes(),
+                signature: signature.to_bytes(),
+            }],
+            next_key: None,
         }))
     }
 
@@ -170,12 +254,10 @@ impl api_server::Api for StubRpcApi {
         &self,
         _request: Request<proto::rpc::SyncChainMmrRequest>,
     ) -> Result<Response<proto::rpc::SyncChainMmrResponse>, Status> {
-        let mock_chain = MockChain::new();
-
         Ok(Response::new(proto::rpc::SyncChainMmrResponse {
             block_range: Some(proto::rpc::BlockRange { block_from: 0, block_to: 0 }),
             mmr_delta: Some(proto::primitives::MmrDelta { forest: 0, data: vec![] }),
-            block_header: Some(to_proto_block_header(&mock_chain.latest_block_header())),
+            block_header: Some(to_proto_block_header(&stub_chain().genesis)),
             block_signature: None,
         }))
     }

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -676,7 +676,10 @@ mod tests {
         AuthSingleSigAclConfig,
         PublicKeyCommitment,
     };
+    use miden_client::block::BlockNumber;
+    use miden_client::crypto::eddsa_25519_sha512::KeyExchangeKey;
     use miden_client::crypto::rpo_falcon512::SecretKey;
+    use miden_client::rpc::encryption::TransactionEncryptionKey;
     use miden_client::store::{NoteFilter, Store};
     use miden_client::testing::MockChain;
     use miden_client::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
@@ -783,6 +786,24 @@ mod tests {
             .unwrap();
         client.ensure_genesis_in_place().await.unwrap();
         client.add_account(&account, false).await.unwrap();
+
+        // The mock RPC serves no transaction encryption key, so seed an unattested one:
+        // submission seals against it and the mock node ignores the sealed payload.
+        let genesis_commitment = client
+            .get_block_header_by_num(BlockNumber::GENESIS)
+            .await
+            .unwrap()
+            .expect("genesis header must be in place")
+            .0
+            .commitment();
+        client
+            .seed_transaction_encryption_key(TransactionEncryptionKey::new_unattested(
+                b"mock-key-id".to_vec(),
+                KeyExchangeKey::new().public_key(),
+                genesis_commitment,
+            ))
+            .await
+            .unwrap();
 
         let (issuance, _) = watch::channel(AssetAmount::new(0).unwrap());
         Faucet {


### PR DESCRIPTION
NOTE: This ships the vendored JS package built from https://github.com/0xMiden/web-sdk/pull/252, but we might want to release `miden-sdk` to NPM before shipping this