### PR TITLE
fix: log the full error chain in the mint span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.16.0 (TBD)
 
-- Emit the full error chain in the `faucet.mint` span by recording errors with their `Debug` implementation ([#267](https://github.com/0xMiden/faucet/pull/267)).
+- Improved mint failure observability: emit the full error chain in the `faucet.mint` span by recording errors with their `Debug` implementation ([#267](https://github.com/0xMiden/faucet/pull/267)).
 
 ## 0.16.0-alpha.1 (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.0 (TBD)
+
+- Emit the full error chain in the `faucet.mint` span by recording errors with their `Debug` implementation ([#267](https://github.com/0xMiden/faucet/pull/267)).
+
 ## 0.16.0-alpha.1 (2026-07-20)
 
 - Updated miden-client dependency to v0.16.0-alpha.1 ([#259](https://github.com/0xMiden/faucet/pull/259))

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -290,7 +290,7 @@ impl Faucet {
     ///
     /// The requests size is guaranteed to be smaller or equal to the batch size set in
     /// `Faucet::run`.
-    #[instrument(parent = None, target = COMPONENT, name = "faucet.mint", skip_all, fields(num_requests, tx_id), err)]
+    #[instrument(parent = None, target = COMPONENT, name = "faucet.mint", skip_all, fields(num_requests, tx_id), err(Debug))]
     async fn mint(
         &mut self,
         requests: impl IntoIterator<Item = (MintRequest, MintResponseSender)>,


### PR DESCRIPTION
Closes https://github.com/0xMiden/faucet/issues/258

### Motivation

When `sync_state` fails, the emitted error only includes the message `"failed to sync state"`, dropping the chain of errors. This makes the traces hard to debug. For example, this is how the error looks when inspecting the traces in Jaeger:

<img width="1241" height="864" alt="log_before_" src="https://github.com/user-attachments/assets/4aa2e705-3de0-40e7-80e3-4d5b48bfd48a" />



This is caused because the `mint` function is instrumented with the `#[instrument(err)]` attribute, which by default it records the error through its `Display` implementation. For `anyhow::Error`, `Display` prints only the outermost context (the `caused by` chain is dropped). So an error inside the mint path is recorded including only the outermost context (e.g. `"failed to sync state"`), missing the actual cause.
The same happens for the `submit_new_transaction` path in the `mint` function.

### Changes

Changes the `mint` function instrumentation attribute from `#[instrument(err)]` to `#[instrument(err(Debug))]` so that the error is recorded using its `Debug` implementation, which includes the full error chain.

With this change, the error now contains the actual cause:

<img width="1818" height="1094" alt="log_now_" src="https://github.com/user-attachments/assets/2974939f-182a-4679-9999-9a9100c49e69" />


