### PR TITLE
fix(api): enforce API key validation to prevent rate limit bypass

### DIFF
--- a/bin/faucet/src/api/mod.rs
+++ b/bin/faucet/src/api/mod.rs
@@ -140,6 +140,18 @@ impl ApiServer {
         api_key: ApiKey,
         request_complexity: u64,
     ) -> Result<(), MintRequestError> {
+        // [GÜVENLİK YAMASI]: Kayıp Yetkilendirme (Missing Authorization) kontrolü eklendi.
+        // Eğer sunucu belirli API anahtarlarıyla başlatılmışsa, gelen `api_key`in
+        // bu set içerisinde olup olmadığı kontrol edilmelidir. Aksi takdirde,
+        // saldırganlar sahte anahtarlarla Rate-Limiter'ı domain bazında atlatabilir.
+        if !self.api_keys.is_empty() && !self.api_keys.contains(&api_key) {
+            tracing::warn!(
+                target: COMPONENT,
+                "Unauthorized API key attempt - blocking potential rate limit bypass"
+            );
+            return Err(MintRequestError::PowError(ChallengeError::InvalidSignature));
+        }
+
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("current timestamp should be greater than unix epoch")


### PR DESCRIPTION
While reviewing the API server implementation, I noticed that `submit_challenge` accepts an `api_key` argument but never actually verifies if it exists in the configured `api_keys` whitelist.

Since the underlying `PoWRateLimiter` relies on the API key (domain) to track and enforce limits, an attacker could currently bypass the rate limiter entirely by simply passing a new, random API key on every request.

This PR adds a straightforward authorization check: if the server is initialized with a set of API keys, it will now explicitly reject requests with unrecognized keys before passing them down to the rate limiter.