### PR TITLE
fix(frontend): remove redundant JSON.parse in getConfig

### DIFF
--- a/bin/faucet/frontend/api.js
+++ b/bin/faucet/frontend/api.js
@@ -12,7 +12,7 @@ export async function getConfig() {
     if (!response.ok) {
         throw new ApiError(response.statusText, response.status);
     }
-    return JSON.parse(await response.json());
+    return await response.json();
 }
 
 export async function getMetadata(backendUrl) {


### PR DESCRIPTION
## Summary

`getConfig` called `JSON.parse` on the result of `response.json()`, which is already an object. That threw `SyntaxError` and blocked frontend init.

## Testing

- Inspected `bin/faucet/frontend/api.js` — returns `await response.json()` directly

Closes #272