### PR TITLE
fix(frontend): preserve fractional token amounts in UI

### DIFF
--- a/bin/faucet/frontend/utils.js
+++ b/bin/faucet/frontend/utils.js
@@ -26,12 +26,17 @@ export const Utils = {
 
     baseUnitsToTokens: (baseUnits, decimals) => {
         return (baseUnits / 10 ** decimals).toLocaleString(undefined, {
-            maximumFractionDigits: 0,
+            maximumFractionDigits: decimals,
         });
     },
 
     tokensToBaseUnits: (tokens, decimals) => {
-        return tokens * (10 ** decimals);
+        const [whole, fraction = ''] = String(tokens).split('.');
+        const paddedFraction = fraction.padEnd(decimals, '0').slice(0, decimals);
+        const scaled =
+            BigInt(whole) * BigInt(10 ** decimals) + BigInt(paddedFraction || '0');
+        const asNumber = Number(scaled);
+        return Number.isSafeInteger(asNumber) ? asNumber : scaled.toString();
     },
 
     idFromBech32: (address) => {


### PR DESCRIPTION
## Summary

`baseUnitsToTokens` used `maximumFractionDigits: 0`, so fractional amounts rendered as whole numbers. Scale with integer/BigInt math instead of float truncation.

## Testing

- Node checks: `baseUnitsToTokens(1500000, 6)` → `1.5`; `tokensToBaseUnits('1.5', 6)` → `1500000`

Closes #273