### PR TITLE
fix(frontend): update wallet adapter package scope

### DIFF
--- a/bin/faucet/frontend/app.js
+++ b/bin/faucet/frontend/app.js
@@ -1,5 +1,5 @@
-import { MidenWalletAdapter } from "@demox-labs/miden-wallet-adapter-miden";
-import { PrivateDataPermission, WalletAdapterNetwork, WalletReadyState } from "@demox-labs/miden-wallet-adapter-base";
+import { MidenWalletAdapter } from "@miden-sdk/miden-wallet-adapter-miden";
+import { PrivateDataPermission, WalletAdapterNetwork, WalletReadyState } from "@miden-sdk/miden-wallet-adapter-base";
 import { Endpoint, NoteId, RpcClient, getWasmOrThrow } from "@miden-sdk/miden-sdk/lazy";
 import { Utils } from './utils.js';
 import { UIController } from './ui.js';

--- a/bin/faucet/frontend/package.json
+++ b/bin/faucet/frontend/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@demox-labs/miden-wallet-adapter-base": "^0.10.0",
-    "@demox-labs/miden-wallet-adapter-miden": "^0.10.0",
+    "@miden-sdk/miden-wallet-adapter-base": "^0.15.3",
+    "@miden-sdk/miden-wallet-adapter-miden": "^0.15.3",
     "@miden-sdk/miden-sdk": "0.16.0-rc.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Summary
Updates the faucet frontend wallet adapter imports and dependencies from the old `@demox-labs` package scope to the active `@miden-sdk` scope.

Fixes #281.

Why
The frontend was still using `@demox-labs/miden-wallet-adapter-base` and `@demox-labs/miden-wallet-adapter-miden`, while the active wallet adapter packages in `0xMiden/wallet-adapter` are published as `@miden-sdk/miden-wallet-adapter-*`. Keeping the old names makes the frontend package metadata and imports stale for current Miden SDK users.

Changes
- Updated `bin/faucet/frontend/package.json` to depend on `@miden-sdk/miden-wallet-adapter-base` and `@miden-sdk/miden-wallet-adapter-miden`.
- Updated the corresponding imports in `bin/faucet/frontend/app.js`.

Testing
- `git diff --check`
- Parsed `bin/faucet/frontend/package.json` with Node
- `npm install --no-package-lock`
- `npm run build`