### PR TITLE
fix(api): report note endpoint failures with accurate status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0 (TBD)
+
+- `/get_note` and `/send_note` now answer with a status code that matches the failure: a note that is not cached is `404` instead of `400`, a faucet started without a note transport URL is `501`, and a transport layer that is unreachable or answers unusably is `502`. Previously every one of these was reported as a `400`, so an outage of the note transport service looked like a client error ([#297](https://github.com/0xMiden/faucet/pull/297)).
+
 ## 0.16.0 (2026-09-08)
 
 - Updated `miden-client` and `miden-node-proto-build` dependencies to v0.16.0, bumped the workspace version to 0.16.0, and updated the declared `rust-version` and the Docker builder image to 1.98.1 ([#300](https://github.com/0xMiden/faucet/pull/300)).

--- a/bin/faucet/src/api/get_note.rs
+++ b/bin/faucet/src/api/get_note.rs
@@ -83,6 +83,15 @@ pub enum NoteRequestError {
 }
 
 impl NoteRequestError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InvalidNoteId => StatusCode::BAD_REQUEST,
+            // The note id parsed, so the request itself is well formed; the note is simply not in
+            // the cache, either because it was never minted here or because it has been pruned.
+            Self::NoteNotFound => StatusCode::NOT_FOUND,
+        }
+    }
+
     /// Take care to not expose internal errors here.
     fn user_facing_error(&self) -> String {
         match self {
@@ -94,6 +103,21 @@ impl NoteRequestError {
 
 impl IntoResponse for NoteRequestError {
     fn into_response(self) -> axum::response::Response {
-        (StatusCode::BAD_REQUEST, self.user_facing_error()).into_response()
+        (self.status_code(), self.user_facing_error()).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_malformed_note_id_is_a_client_error() {
+        assert_eq!(NoteRequestError::InvalidNoteId.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn a_note_that_is_not_cached_is_not_found() {
+        assert_eq!(NoteRequestError::NoteNotFound.status_code(), StatusCode::NOT_FOUND);
     }
 }

--- a/bin/faucet/src/api/send_note.rs
+++ b/bin/faucet/src/api/send_note.rs
@@ -70,6 +70,19 @@ pub enum SendNoteError {
 }
 
 impl SendNoteError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InvalidNoteId => StatusCode::BAD_REQUEST,
+            Self::NoteNotFound => StatusCode::NOT_FOUND,
+            // The note transport layer is a server-side dependency, so none of its failures are
+            // caused by the request. `Disabled` is a deployment that was never configured with a
+            // transport URL, which no client can correct by retrying differently; every other
+            // variant is the upstream service being unreachable or answering unusably.
+            Self::NoteTransportError(NoteTransportError::Disabled) => StatusCode::NOT_IMPLEMENTED,
+            Self::NoteTransportError(_) => StatusCode::BAD_GATEWAY,
+        }
+    }
+
     /// Take care to not expose internal errors here.
     fn user_facing_error(&self) -> String {
         match self {
@@ -84,6 +97,46 @@ impl SendNoteError {
 
 impl IntoResponse for SendNoteError {
     fn into_response(self) -> axum::response::Response {
-        (StatusCode::BAD_REQUEST, self.user_facing_error()).into_response()
+        (self.status_code(), self.user_facing_error()).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_malformed_note_id_is_a_client_error() {
+        assert_eq!(SendNoteError::InvalidNoteId.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn a_note_that_is_not_cached_is_not_found() {
+        assert_eq!(SendNoteError::NoteNotFound.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    /// A faucet started without a transport URL cannot serve this endpoint at all. That is a
+    /// deployment decision, not something the caller got wrong.
+    #[test]
+    fn a_disabled_transport_layer_is_not_implemented() {
+        assert_eq!(
+            SendNoteError::NoteTransportError(NoteTransportError::Disabled).status_code(),
+            StatusCode::NOT_IMPLEMENTED,
+        );
+    }
+
+    /// An unreachable or misbehaving transport service is an upstream failure, so it has to be
+    /// reported as one: a 4xx would tell operators and clients that the caller was at fault.
+    #[test]
+    fn an_upstream_transport_failure_is_a_gateway_error() {
+        for error in [
+            NoteTransportError::Network("connection reset".to_string()),
+            NoteTransportError::PaginationDidNotTerminate(64),
+        ] {
+            assert_eq!(
+                SendNoteError::NoteTransportError(error).status_code(),
+                StatusCode::BAD_GATEWAY,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`/get_note` and `/send_note` answer every failure with `400 Bad Request`, including failures the caller has no part in. The most consequential case is the note transport layer.

`SendNoteError::NoteTransportError` wraps the transport client, and none of `NoteTransportError`'s variants describes a bad request:

| variant | what it means |
| --- | --- |
| `Disabled` | the faucet was started without a note transport URL |
| `Connection` | could not reach the transport service |
| `Network` | the transport RPC failed |
| `Deserialization` | the transport service answered with something unusable |
| `PaginationDidNotTerminate` | the transport service's cursor never converged |

All five are server-side or upstream conditions, and all five currently surface as `400`. So while the note transport service is down, every `/send_note` call is recorded as a client error: it does not appear in server error rates, and it tells clients and proxies that retrying is pointless. `Disabled` has the same problem in a different way — it is a deployment that never configured the endpoint, which no caller can fix by changing their request.

`NoteNotFound` was also a `400` on both endpoints, even though the note id parsed and the request was well formed. The note is either not from this faucet or has been pruned from the cache after `NOTE_RETENTION_BLOCKS`.

## Change

Give each failure the status it deserves:

- `NoteNotFound` → `404 Not Found` (both endpoints)
- `NoteTransportError::Disabled` → `501 Not Implemented`
- every other `NoteTransportError` → `502 Bad Gateway`
- `InvalidNoteId` stays `400`

Both error types now carry a `status_code` method, matching the shape `GetTokenError` already uses in `get_tokens.rs`.

## Frontend

`app.js` switches on 400, 429, 500 and 503 and sends everything else to `showRequestFailedError`, so the new codes take that generic path. That is also an improvement in what the user sees: a transport outage currently renders as "Invalid request".

## Tests

Six unit tests covering each mapping, including both an upstream failure and the disabled case.

- `cargo test -p miden-faucet --bins` — 21 passed. `frontend_mint_tokens` fails in my environment because `chromedriver` is not installed; it is unrelated to this change and fails the same way on a clean `next`.
- `cargo clippy -p miden-faucet --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt` — clean

Note that this changes response codes on two public endpoints, so tell me if you would rather treat it as breaking and note it as such in the changelog.
