### PR TITLE
fix(faucet): reject non-positive PoW growth rate and zero base amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `start` now rejects a non-positive or non-finite `--pow-growth-rate` and a zero `--base-amount` at startup, and the PoW rate limiter clamps the load multiplier to at least `1`, so a misconfigured growth rate no longer makes every challenge request panic with a division by zero ([#304](https://github.com/0xMiden/faucet/issues/304)).
+
 ## 0.16.0 (2026-09-08)
 
 - Updated `miden-client` and `miden-node-proto-build` dependencies to v0.16.0, bumped the workspace version to 0.16.0, and updated the declared `rust-version` and the Docker builder image to 1.98.1 ([#300](https://github.com/0xMiden/faucet/pull/300)).

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -189,7 +189,10 @@ pub enum Command {
         ///
         /// Meaning, the difficulty bits of the challenge will increase approximately by
         /// `log2(growth_rate * num_active_challenges)`.
-        #[arg(long = "pow-growth-rate", value_name = "F64", env = ENV_POW_GROWTH_RATE, default_value = "0.1")]
+        ///
+        /// Must be a finite number greater than zero: a zero or negative growth rate makes the
+        /// load difficulty zero, which no challenge target can be derived from.
+        #[arg(long = "pow-growth-rate", value_name = "F64", env = ENV_POW_GROWTH_RATE, default_value = "0.1", value_parser = parse_pow_growth_rate)]
         pow_growth_rate: f64,
 
         /// The interval at which the `PoW` challenge cache is cleaned up.
@@ -208,7 +211,9 @@ pub enum Command {
         ///
         /// The request complexity for challenges is computed as: `request_complexity = (amount /
         /// base_amount) + 1`
-        #[arg(long = "base-amount", value_name = "U64", env = ENV_BASE_AMOUNT, default_value = "100000000")]
+        ///
+        /// Must be at least 1, since the requested amount is divided by it.
+        #[arg(long = "base-amount", value_name = "U64", env = ENV_BASE_AMOUNT, default_value = "100000000", value_parser = clap::value_parser!(u64).range(1..))]
         base_amount: u64,
 
         /// Enables the exporting of traces for OpenTelemetry.
@@ -638,6 +643,19 @@ async fn remove_api_key_from_store(store: &SqliteStore, key: &ApiKey) -> anyhow:
 
 /// Parses the node endpoint from the cli arguments. If an explicit url is provided, it is used.
 /// Otherwise, it is derived from the specified network.
+/// Parses the `PoW` growth rate, rejecting values that would zero out the load difficulty.
+///
+/// `get_load_difficulty` multiplies the number of active challenges by this rate and rounds up, so
+/// a non-positive (or `NaN`) rate yields a difficulty of `0` and every challenge request divides by
+/// zero. Rejecting those values here fails at startup instead of on the first request.
+fn parse_pow_growth_rate(value: &str) -> Result<f64, String> {
+    let rate: f64 = value.parse().map_err(|err| format!("invalid growth rate: {err}"))?;
+    if !rate.is_finite() || rate <= 0.0 {
+        return Err(format!("growth rate must be a finite number greater than 0, got {value}"));
+    }
+    Ok(rate)
+}
+
 fn parse_node_endpoint(node_url: Option<Url>, network: &FaucetNetwork) -> anyhow::Result<Endpoint> {
     let url = if let Some(node_url) = node_url {
         node_url.to_string()
@@ -689,6 +707,46 @@ mod tests {
         let mut command_args = vec!["miden-faucet", "init"];
         command_args.extend_from_slice(args);
         Cli::try_parse_from(command_args)
+    }
+
+    /// Parses a `start` invocation, with `args` appended to the fixed prefix.
+    fn parse_start(args: &[&str]) -> Result<Cli, clap::Error> {
+        let mut command_args = vec!["miden-faucet", "start"];
+        command_args.extend_from_slice(args);
+        Cli::try_parse_from(command_args)
+    }
+
+    /// A non-positive or non-finite growth rate would make the load difficulty zero and every
+    /// challenge request divide by zero, so it must be rejected when parsing the CLI.
+    #[test]
+    fn start_rejects_non_positive_pow_growth_rate() {
+        for rate in ["0", "-0.5", "NaN", "inf"] {
+            // `--flag=value` keeps a leading `-` from being read as another flag.
+            let arg = format!("--pow-growth-rate={rate}");
+            let Err(error) = parse_start(&[&arg]) else {
+                panic!("--pow-growth-rate {rate} should be rejected")
+            };
+            assert_eq!(error.kind(), ErrorKind::ValueValidation, "rate {rate}");
+        }
+    }
+
+    #[test]
+    fn start_accepts_positive_pow_growth_rate() {
+        let cli = parse_start(&["--pow-growth-rate", "0.25"]).expect("0.25 is a valid rate");
+        let crate::Command::Start { pow_growth_rate, .. } = cli.command else {
+            panic!("expected the start command")
+        };
+        assert!((pow_growth_rate - 0.25).abs() < f64::EPSILON);
+    }
+
+    /// The requested amount is divided by the base amount, so zero must be rejected.
+    #[test]
+    fn start_rejects_zero_base_amount() {
+        let Err(error) = parse_start(&["--base-amount", "0"]) else {
+            panic!("--base-amount 0 should be rejected")
+        };
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        assert!(parse_start(&["--base-amount", "1"]).is_ok());
     }
 
     /// `--import` and `--faucet-account-id` are all-or-nothing: each requires the other.

--- a/crates/pow/src/lib.rs
+++ b/crates/pow/src/lib.rs
@@ -119,7 +119,11 @@ impl PoWRateLimiter {
     /// Returns the load difficulty for a given domain.
     ///
     /// The load difficulty is computed as:
-    /// `2^baseline * ceil((num_active_challenges + 1) * growth_rate)`
+    /// `2^baseline * max(1, ceil((num_active_challenges + 1) * growth_rate))`
+    ///
+    /// The multiplier is clamped to at least `1` so that a non-positive (or `NaN`) growth rate
+    /// degrades to a constant `2^baseline` difficulty instead of a zero difficulty, which the
+    /// challenge target could not be derived from.
     pub fn get_load_difficulty(&self, domain: impl Into<Domain>) -> u64 {
         let num_challenges = self
             .challenges
@@ -128,9 +132,12 @@ impl PoWRateLimiter {
             .num_challenges_for_domain(&domain.into());
 
         #[allow(clippy::cast_precision_loss, reason = "num_challenges is smaller than f64::MAX")]
-        #[allow(clippy::cast_sign_loss, reason = "growth_rate and num_challenges are positive")]
+        #[allow(
+            clippy::cast_sign_loss,
+            reason = "a negative product saturates to 0 and is clamped to 1 below"
+        )]
         let growth_multiplier =
-            ((num_challenges + 1) as f64 * self.config.growth_rate).ceil() as u64;
+            (((num_challenges + 1) as f64 * self.config.growth_rate).ceil() as u64).max(1);
         2_u64.pow(self.config.baseline.into()).saturating_mul(growth_multiplier)
     }
 
@@ -141,7 +148,7 @@ impl PoWRateLimiter {
     ///
     /// Where:
     /// * `request_difficulty = load_difficulty * request_complexity`
-    /// * `load_difficulty = 2^baseline * ceil((num_active_challenges + 1) * growth_rate)`
+    /// * `load_difficulty = 2^baseline * max(1, ceil((num_active_challenges + 1) * growth_rate))`
     fn get_challenge_target(&self, domain: &Domain, request_complexity: u64) -> u64 {
         if request_complexity == 0 {
             return u64::MAX;

--- a/crates/pow/src/tests.rs
+++ b/crates/pow/src/tests.rs
@@ -362,3 +362,24 @@ async fn submit_challenge_while_previous_one_is_not_cleaned_up() {
     assert_eq!(pow.challenges.read().unwrap().num_challenges_for_domain(&domain_1), 1);
     assert_eq!(pow.challenges.read().unwrap().num_challenges_for_domain(&domain_2), 1);
 }
+
+/// A non-positive or `NaN` growth rate must not zero out the load difficulty: the challenge target
+/// is `u64::MAX / difficulty`, so a zero difficulty would make `build_challenge` divide by zero.
+#[tokio::test]
+async fn non_positive_growth_rate_falls_back_to_baseline_difficulty() {
+    for growth_rate in [0.0, -0.5, f64::NAN] {
+        let pow = PoWRateLimiter::new_with_cleanup(
+            [1u8; 32],
+            PoWRateLimiterConfig {
+                challenge_lifetime: Duration::from_secs(30),
+                growth_rate,
+                baseline: 4,
+                cleanup_interval: Duration::from_secs(2),
+            },
+        );
+
+        assert_eq!(pow.get_load_difficulty([0u8; 32]), 1 << 4, "growth rate {growth_rate}");
+        let challenge = pow.build_challenge([0u8; 32], [0u8; 32], 1);
+        assert_eq!(challenge.target(), u64::MAX >> 4, "growth rate {growth_rate}");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #304.

`--pow-growth-rate` accepted `0`, negative and non-finite values and `--base-amount` accepted `0`. The faucet started normally, but every `GET /pow` and `GET /get_tokens` request then panicked with `attempt to divide by zero` (`crates/pow/src/lib.rs:151`), because a non-positive growth rate makes `get_load_difficulty` return `0` and `get_challenge_target` divides `u64::MAX` by it; `compute_request_complexity` divides by `base_amount` the same way.

## Changes

- `bin/faucet/src/main.rs`: `--pow-growth-rate` gets a `value_parser` that requires a finite number `> 0`; `--base-amount` is bounded to `1..` (same style as the existing `--pow-baseline` range). A misconfiguration now fails at startup with a clap error instead of on the first request.
- `crates/pow/src/lib.rs`: `get_load_difficulty` clamps the growth multiplier to at least `1`, so library users of `miden-pow-rate-limiter` cannot hit the division by zero either; a non-positive rate degrades to the constant `2^baseline` difficulty. Doc comments updated to the new formula.
- Tests: CLI tests for the rejected and accepted values (`start_rejects_non_positive_pow_growth_rate`, `start_accepts_positive_pow_growth_rate`, `start_rejects_zero_base_amount`) and a rate-limiter test that `0.0`, `-0.5` and `NaN` all yield the baseline difficulty and a valid target.
- `CHANGELOG.md` entry under `Unreleased`.

## Test plan

- `cargo test -p miden-pow-rate-limiter --features tokio` (13 tests) and `cargo test -p miden-faucet --bin miden-faucet` (all pass except the chromedriver-based `frontend_mint_tokens` e2e test, which needs a local browser driver).
- `cargo clippy --all-targets --all-features -- -D warnings` and nightly `cargo fmt --check` are clean.

## Open questions

- If you would rather keep the rate limiter minimal, the `max(1)` clamp can be dropped and only the CLI validation kept; the CLI check alone is enough to fix the reported panic for the binary.
